### PR TITLE
Support multiple permissions per required resource app

### DIFF
--- a/src/AzureEx.Resources/Add-AzureExAdRequiredResourceAccessPermission.ps1
+++ b/src/AzureEx.Resources/Add-AzureExAdRequiredResourceAccessPermission.ps1
@@ -1,0 +1,26 @@
+function Add-AzureExAdRequiredResourceAccessPermission
+{
+    <#
+    .Synopsis
+        Adds a AzureExAdRequiredResourceAccessPermission to an existing AzureExAdRequiredResourceAccessApplication.
+    .Example
+        PS> $raa = New-AzureExAdRequiredResourceAccessApplication -ApplicationId "00000002-0000-0000-c000-000000000000" -PermissionId "00000000-0000-0000-0000-000000000001" -PermissionType 'Scope'
+        PS> Add-AzureExAdRequiredResourceAccessPermission -RequiredResourceAccessApplication $raa -PermissionId "00000000-0000-0000-0000-000000000002" -PermissionType 'Role'
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject] $RequiredResourceAccessApplication,
+
+        [Parameter(Mandatory=$true)]
+        [guid] $PermissionId,
+
+        [string] $PermissionType = 'Scope'
+        )
+    $resourceAccess = @{
+        id = $PermissionId
+        type = $PermissionType
+    }
+    $RequiredResourceAccessApplication.resourceAccess += $resourceAccess
+    $result = $RequiredResourceAccessApplication
+}

--- a/src/AzureEx.Resources/New-AzureExAdApplication.ps1
+++ b/src/AzureEx.Resources/New-AzureExAdApplication.ps1
@@ -6,9 +6,11 @@ function New-AzureExAdApplication
         cmdlets cannot create a usable AAD application that has correct permissions to other applications such as the Windows Azure Active
         Directory, or any other custom applications. 
     .Example
-        PS> New-AzureExAdApplication -DisplayName MyWebApp -IdentifierUris http://mypp
+        PS> New-AzureExAdApplication -DisplayName MyWebApp -IdentifierUris http://myapp1
     .Example
-        PS> New-AzureExAdApplication -DisplayName MyWebApp -IdentifierUris http://mypp -AppSecret $password -AppYears 2
+        PS> New-AzureExAdApplication -DisplayName MyWebApp -IdentifierUris http://myapp1 -AppSecrets $password -AppYears 2
+    .Example
+        PS> New-AzureExAdApplication -DisplayName MyWebApp -IdentifierUris http://myapp1 -RequiredResourceAccessApplications $requireResourceAccess -PermissionsToOtherApplicationIdentifierUris http://myapp2, http://myapp3
     .Example
         PS> New-AzureExAdApplication -DisplayName MyWebApp -IdentifierUris http://myclient -PermissionsToOtherApplicationIdentifierUris http://myapp
     .Example
@@ -39,7 +41,9 @@ function New-AzureExAdApplication
 
         [switch] $MultiTenant,
 
-        [string] $TenantId
+        [string] $TenantId,
+
+        [array] $RequiredResourceAccessApplications
         )
     $ErrorActionPreference = 'Stop'
 
@@ -52,7 +56,11 @@ function New-AzureExAdApplication
         $app.publicClient = $true 
     }
     if ($ReplyUrls) { $app.replyUrls = $ReplyUrls }
-    $app.requiredResourceAccess = @((Get-AzureExAdApplicationOauth2Permission AadSigninAndReadUserProfile))
+    if ($RequiredResourceAccessApplications) {
+        $app.requiredResourceAccess = $RequiredResourceAccessApplications
+    } else {
+        $app.requiredResourceAccess = @((Get-AzureExAdApplicationOauth2Permission AadSigninAndReadUserProfile))
+    }
     if ($AppSecrets) {
         [array] $app.passwordCredentials = $AppSecrets | % {
             New-AzureExAdPasswordCredential $_ $AppYears

--- a/src/AzureEx.Resources/New-AzureExAdRequiredResourceAccessApplication.ps1
+++ b/src/AzureEx.Resources/New-AzureExAdRequiredResourceAccessApplication.ps1
@@ -1,0 +1,33 @@
+function New-AzureExAdRequiredResourceAccessApplication
+{
+    <#
+    .Synopsis
+        Create a new AAD AzureExAdRequiredResourceAccessApplication object with an initial permission and permission type specified.
+        Additional permissions for the object can be added with Add-AzureExAdRequiredResourceAccessPermission.
+    .Example
+        PS> New-AzureExAdRequiredResourceAccessApplicationn -ApplicationId "00000000-0000-0000-0000-000000000001" -ReplyUrls https://myapp1 -PermissionsToOtherApplicationIdentifierUris http://myapp2
+    .Example
+        PS> $requireResourceAccess = @()
+        PS> $resourceApplication1 = New-AzureExAdRequiredResourceAccessApplication -ApplicationId "00000002-0000-0000-c000-000000000000" -PermissionId "00000000-0000-0000-0000-000000000002" -PermissionType 'Scope'
+        PS> Add-AzureExAdRequiredResourceAccessPermission -RequiredResourceAccessApplication $resourceApplication1 -PermissionId "00000000-0000-0000-0000-000000000003" -PermissionType 'Role'
+        PS> $resourceApplication2 = New-AzureExAdRequiredResourceAccessApplication -ApplicationId "00000003-0000-0000-c000-000000000000" -PermissionId "00000000-0000-0000-0000-000000000004" -PermissionType 'Scope'
+        PS> $requireResourceAccess += $resourceApplication1, $resourceApplication2
+        PS> New-AzureExAdApplication -DisplayName MyApp1 -IdentifierUris https://myapp1 -ReplyUrls https://myapp1 -RequiredResourceAccessApplications $requireResourceAccess -PermissionsToOtherApplicationIdentifierUris https://myapp2
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string] $ApplicationId,
+
+        [Parameter(Mandatory=$true)]
+        [guid] $PermissionId,
+
+        [string] $PermissionType = 'Scope'
+        )
+    #$resourceAccess = [PSCustomObject]@{ id = $PermissionId; type = $PermissionType }
+    #$result = [PSCustomObject]@{resourceAppId = $ApplicationId; resourceAccess =  @();}
+    $resourceAccess = @{ id = $PermissionId; type = $PermissionType }
+    $result = @{resourceAppId = $ApplicationId; resourceAccess =  @();}
+    $result.resourceAccess += $resourceAccess
+    $result
+}


### PR DESCRIPTION
Added support to add more than one permission and permission type to an application that is added as a requiredResourceAccess item. If RequiredResourceAccessApplication is passed as a parameter to New-AzureExAdApplication, do not automatically add Azure AD Sign in and Read User Profile.